### PR TITLE
chore(docs): remove `eslint4b`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 19
           branches: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: npm run test
 
       - name: ⬆️ Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   release:
     name: 🚀 Release
@@ -108,7 +108,7 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 19
           branches: |

--- a/docs/.vuepress/components/eslint-playground.vue
+++ b/docs/.vuepress/components/eslint-playground.vue
@@ -95,7 +95,7 @@ export default {
 
     async mounted() {
         // Load linter.
-        const { default: Linter } = await import("eslint4b")
+        const { Linter } = await import("eslint/lib/linter")
         const linter = (this.linter = new Linter())
 
         for (const ruleId of Object.keys(rules)) {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const path = require("path")
-// eslint-disable-next-line @eslint-community/mysticatea/node/no-extraneous-require
 const webpack = require("webpack")
 const { withCategories } = require("../../scripts/lib/rules")
 require("../../scripts/update-docs-headers")

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,8 @@
 "use strict"
 
-const path = require('path')
-const webpack = require('webpack')
+const path = require("path")
+// eslint-disable-next-line @eslint-community/mysticatea/node/no-extraneous-require
+const webpack = require("webpack")
 const { withCategories } = require("../../scripts/lib/rules")
 require("../../scripts/update-docs-headers")
 require("../../scripts/update-docs-index")
@@ -27,8 +28,7 @@ module.exports = {
         nav: [
             {
                 text: "Changelog",
-                link:
-                    "https://github.com/eslint-community/eslint-plugin-eslint-comments/releases",
+                link: "https://github.com/eslint-community/eslint-plugin-eslint-comments/releases",
             },
         ],
 
@@ -40,7 +40,7 @@ module.exports = {
                 ...withCategories.map(({ category, rules }) => ({
                     title: `Rules in ${category}`,
                     collapsable: false,
-                    children: rules.map(rule => `/rules/${rule.name}`),
+                    children: rules.map((rule) => `/rules/${rule.name}`),
                 })),
             ],
         },
@@ -50,18 +50,18 @@ module.exports = {
     configureWebpack: {
         plugins: [
             new webpack.DefinePlugin({
-                'process.env.TIMING': JSON.stringify(""),
-            })
+                "process.env.TIMING": JSON.stringify(""),
+            }),
         ],
         resolve: {
             alias: {
                 esquery: path.resolve(
                     __dirname,
-                    "../../node_modules/esquery/dist/esquery.min.js",
+                    "../../node_modules/esquery/dist/esquery.min.js"
                 ),
                 "@eslint/eslintrc/universal": path.resolve(
                     __dirname,
-                    "../../node_modules/@eslint/eslintrc/dist/eslintrc-universal.cjs",
+                    "../../node_modules/@eslint/eslintrc/dist/eslintrc-universal.cjs"
                 ),
             },
         },
@@ -73,7 +73,7 @@ module.exports = {
                     options: {
                         search: "[\\s\\S]+", // whole file.
                         replace:
-                            `module.exports = () => [require("eslint/lib/linter").Linter]`,
+                            'module.exports = () => [require("eslint/lib/linter").Linter]',
                         flags: "g",
                     },
                 },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,7 @@
 "use strict"
 
+const path = require('path')
+const webpack = require('webpack')
 const { withCategories } = require("../../scripts/lib/rules")
 require("../../scripts/update-docs-headers")
 require("../../scripts/update-docs-index")
@@ -44,7 +46,25 @@ module.exports = {
         },
     },
 
+    enhanceAppFiles: require.resolve("./enhanceApp.mjs"),
     configureWebpack: {
+        plugins: [
+            new webpack.DefinePlugin({
+                'process.env.TIMING': JSON.stringify(""),
+            })
+        ],
+        resolve: {
+            alias: {
+                esquery: path.resolve(
+                    __dirname,
+                    "../../node_modules/esquery/dist/esquery.min.js",
+                ),
+                "@eslint/eslintrc/universal": path.resolve(
+                    __dirname,
+                    "../../node_modules/@eslint/eslintrc/dist/eslintrc-universal.cjs",
+                ),
+            },
+        },
         module: {
             rules: [
                 {
@@ -53,7 +73,7 @@ module.exports = {
                     options: {
                         search: "[\\s\\S]+", // whole file.
                         replace:
-                            'module.exports = () => [require("eslint4b/dist/linter")]',
+                            `module.exports = () => [require("eslint/lib/linter").Linter]`,
                         flags: "g",
                     },
                 },

--- a/docs/.vuepress/enhanceApp.mjs
+++ b/docs/.vuepress/enhanceApp.mjs
@@ -1,3 +1,4 @@
+/* globals window */
 export default () => {
     if (typeof window !== "undefined") {
         if (typeof window.process === "undefined") {

--- a/docs/.vuepress/enhanceApp.mjs
+++ b/docs/.vuepress/enhanceApp.mjs
@@ -1,0 +1,9 @@
+export default () => {
+    if (typeof window !== "undefined") {
+        if (typeof window.process === "undefined") {
+            window.process = {
+                cwd: () => undefined,
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@vuepress/plugin-pwa": "^1.9.9",
     "cross-spawn": "^7.0.3",
     "eslint": "^8.46.0",
-    "eslint4b": "^7.32.0",
     "fs-extra": "^10.1.0",
     "mocha": "^9.2.2",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "semver": "^7.5.4",
     "string-replace-loader": "^3.1.0",
     "vue-eslint-editor": "^1.1.0",
-    "vuepress": "^1.9.9"
+    "vuepress": "^1.9.9",
+    "webpack": "^4.47.0"
   },
   "scripts": {
     "preversion": "npm test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "opener": "^1.5.2",
     "rimraf": "^3.0.2",
     "semver": "^7.5.4",
-    "string-replace-loader": "^3.1.0",
+    "string-replace-loader": "^2.3.0",
     "vue-eslint-editor": "^1.1.0",
     "vuepress": "^1.9.9",
     "webpack": "^4.47.0"


### PR DESCRIPTION
This PR removes eslint4b from dev dependencies.
Also change eslint in dev dependencies to v8. But we get an error when linting. This is because `@mysticatea/eslint-plugin` does not support eslint v8. We need to replace it with the `eslint-community` package first.

#20 is a PR that solves dependency issues.