### PR TITLE
refactor: use newer ESLint syntax

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -6,23 +6,22 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
-const linter = new CLIEngine({ fix: true })
+const { ESLint } = require("eslint")
+const linter = new ESLint({ fix: true })
 
 /**
  * Format a given text.
  * @param {string} text The text to format.
- * @returns {string} The formatted text.
+ * @returns {Promise<string>} The formatted text.
  */
 function format(text) {
-    const lintResult = linter.executeOnText(text)
-    return lintResult.results[0].output || text
+    return linter.lintText(text).then(([{ output }]) => output || text)
 }
 
 /**
  * Create the index file content of a given directory.
  * @param {string} dirPath The path to the directory to create index.
- * @returns {string} The index file content.
+ * @returns {Promise<string>} The index file content.
  */
 function createIndex(dirPath) {
     const dirName = path.basename(dirPath)

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -21,5 +21,7 @@ for (const dirPath of [
     path.resolve(__dirname, "../lib/rules"),
     path.resolve(__dirname, "../lib/utils"),
 ]) {
-    fs.writeFileSync(`${dirPath}.js`, createIndex(dirPath))
+    createIndex(dirPath).then(content =>
+        fs.writeFileSync(`${dirPath}.js`, content)
+    )
 }

--- a/tests/lib/rules/disable-enable-pair.js
+++ b/tests/lib/rules/disable-enable-pair.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/disable-enable-pair")
 const tester = new RuleTester()
 
@@ -81,7 +80,7 @@ var foo = 1
             options: [{ allowWholeFile: true }],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   `
 /*eslint-disable no-undef -- description*/
@@ -211,7 +210,7 @@ console.log();
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-aggregating-enable.js
+++ b/tests/lib/rules/no-aggregating-enable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-aggregating-enable")
 const tester = new RuleTester()
 
@@ -67,7 +66,7 @@ tester.run("no-aggregating-enable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-duplicate-disable.js
+++ b/tests/lib/rules/no-duplicate-disable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-duplicate-disable")
 const tester = new RuleTester()
 
@@ -123,7 +122,7 @@ tester.run("no-duplicate-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-restricted-disable.js
+++ b/tests/lib/rules/no-restricted-disable.js
@@ -5,7 +5,6 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
 const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-restricted-disable")
 const coreRules = new Linter().getRules()
@@ -157,7 +156,7 @@ tester.run("no-restricted-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: "/*eslint-disable -- description*/",

--- a/tests/lib/rules/no-unlimited-disable.js
+++ b/tests/lib/rules/no-unlimited-disable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unlimited-disable")
 const tester = new RuleTester()
 
@@ -95,7 +94,7 @@ tester.run("no-unlimited-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: "/*eslint-disable -- description */",

--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -20,7 +20,7 @@ const path = require("path")
 const spawn = require("cross-spawn")
 const rimraf = require("rimraf")
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
+const { Linter } = require("eslint")
 
 /**
  * Run eslint CLI command with a given source code.
@@ -169,7 +169,7 @@ var foo = 3  /*eslint-disable-line no-shadow*/
 }
 `,
             // -- description
-            ...(semver.satisfies(eslintVersion, ">=7.0.0")
+            ...(semver.satisfies(Linter.version, ">=7.0.0")
                 ? [
                       `/*eslint no-undef:error*/
 var a = b //eslint-disable-line -- description`,
@@ -835,7 +835,7 @@ var a = b /*eslint-disable-line no-undef*/`,
                 reportUnusedDisableDirectives: true,
             },
             // -- description
-            ...(semver.satisfies(eslintVersion, ">=7.0.0")
+            ...(semver.satisfies(Linter.version, ">=7.0.0")
                 ? [
                       {
                           code: `/*eslint no-undef:off*/

--- a/tests/lib/rules/no-unused-enable.js
+++ b/tests/lib/rules/no-unused-enable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unused-enable")
 const tester = new RuleTester()
 
@@ -87,7 +86,7 @@ var a = b
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0")
+        ...(semver.satisfies(Linter.version, ">=7.0.0")
             ? [
                   {
                       code: "/*eslint-enable -- description*/",

--- a/tests/lib/rules/no-use.js
+++ b/tests/lib/rules/no-use.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-use")
 const tester = new RuleTester()
 

--- a/tests/lib/rules/require-description.js
+++ b/tests/lib/rules/require-description.js
@@ -5,12 +5,11 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/require-description")
 const tester = new RuleTester()
 
-if (!semver.satisfies(eslintVersion, ">=7.0.0")) {
+if (!semver.satisfies(Linter.version, ">=7.0.0")) {
     // This rule can only be used with ESLint v7.x or later.
     return
 }


### PR DESCRIPTION
- `CLIEngine` is deprecated in ESLint v7 & removed in ESLint v8
- deep imports won't be supported anymore in ESLint v8