### PR TITLE
chore(docs): add SW to clear cached data in `vuepress/pwa`

### DIFF
--- a/docs/.vitepress/public/service-worker.js
+++ b/docs/.vitepress/public/service-worker.js
@@ -1,0 +1,18 @@
+"use strict"
+
+// https://github.com/NekR/self-destroying-sw
+/* globals self */
+self.addEventListener("install", () => {
+    self.skipWaiting()
+})
+
+self.addEventListener("activate", () => {
+    self.registration
+        .unregister()
+        .then(() => self.clients.matchAll())
+        .then((clients) => {
+            for (const client of clients) {
+                client.navigate(client.url)
+            }
+        })
+})


### PR DESCRIPTION
I replaced Vuepress with Vitepress in #114, but because we was using a plugin `@vuepress/pwa` on previous site. This plug-in registers a service worker locally for visitors who visit the site, and most of the site data is cached by that SW, making it impossible to display new site pages.


This PR registers a new service worker and makes the new pages displayed.