### PR TITLE
Add new rule comment-style

### DIFF
--- a/docs/rules/comment-style.md
+++ b/docs/rules/comment-style.md
@@ -1,0 +1,27 @@
+# eslint-comments/comment-style
+
+> require eslint-disable-line and eslint-disable-next-line to be line comments
+
+ESLint rules can be disabled using `eslint-disable-line` or `eslint-disable-next-line` comments.
+These comments may be either line comments, or block comments. This rule disallows the use of
+block comments for these ESLint directives.
+
+## Rule Details
+
+Examples of :-1: **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint eslint-comments/comment-style: error */
+
+/* eslint-disable-line */
+/* eslint-disable-next-line */
+" />
+
+Examples of :+1: **correct** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint eslint-comments/comment-style: error */
+
+// eslint-disable-line
+// eslint-disable-next-line
+<div>{/* eslint-disable-line */}</div>
+<div>{/* eslint-disable-next-line */}</div>
+" />

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -7,6 +7,7 @@
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [eslint-comments/<wbr>comment-style](./comment-style.md) | require `eslint-disable-line` and `eslint-disable-next-line` to be line comments | ✒️ |
 | [@eslint-community/eslint-comments/<wbr>disable-enable-pair](./disable-enable-pair.md) | require a `eslint-enable` comment for every `eslint-disable` comment | 🌟 |
 | [@eslint-community/eslint-comments/<wbr>no-aggregating-enable](./no-aggregating-enable.md) | disallow a `eslint-enable` comment for multiple `eslint-disable` comments | 🌟 |
 | [@eslint-community/eslint-comments/<wbr>no-duplicate-disable](./no-duplicate-disable.md) | disallow duplicate `eslint-disable` comments | 🌟 |

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -2,6 +2,7 @@
 "use strict"
 
 module.exports = {
+    "comment-style": require("./rules/comment-style"),
     "disable-enable-pair": require("./rules/disable-enable-pair"),
     "no-aggregating-enable": require("./rules/no-aggregating-enable"),
     "no-duplicate-disable": require("./rules/no-duplicate-disable"),

--- a/lib/rules/comment-style.js
+++ b/lib/rules/comment-style.js
@@ -1,0 +1,65 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const utils = require("../internal/utils")
+
+const directives = new Set(["eslint-disable-line", "eslint-disable-next-line"])
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "require `eslint-disable-line` and `eslint-disable-next-line` to be line comments",
+            category: "Stylistic Issues",
+            recommended: false,
+            url: "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/comment-style.html",
+        },
+        fixable: "code",
+        messages: {
+            disallow: "Expected a line comment.",
+        },
+        schema: [],
+        type: "layout",
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode()
+        const ignore = new Set()
+
+        return {
+            JSXExpressionContainer(node) {
+                ignore.add(...sourceCode.getCommentsInside(node))
+            },
+            "Program:exit"() {
+                for (const comment of sourceCode.getAllComments()) {
+                    if (comment.type === "Line") {
+                        continue
+                    }
+                    if (ignore.has(comment)) {
+                        continue
+                    }
+                    const directiveComment =
+                        utils.parseDirectiveComment(comment)
+                    if (directiveComment == null) {
+                        continue
+                    }
+                    if (!directives.has(directiveComment.kind)) {
+                        continue
+                    }
+                    context.report({
+                        messageId: "disallow",
+                        node: comment,
+                        fix: (fixer) =>
+                            fixer.replaceText(
+                                comment,
+                                `//${comment.value.replace(/\s+$/u, "")}`
+                            ),
+                    })
+                }
+            },
+        }
+    },
+}

--- a/tests/lib/rules/comment-style.js
+++ b/tests/lib/rules/comment-style.js
@@ -1,0 +1,51 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const RuleTester = require("eslint").RuleTester
+const rule = require("../../../lib/rules/comment-style")
+const tester = new RuleTester()
+
+tester.run("comment-style", rule, {
+    valid: [
+        "// eslint-disable-line",
+        "// eslint-disable-next-line",
+        "// eslint-disable-line semi",
+        "// eslint-disable-next-line semi",
+        {
+            code: "<div>{/* eslint-disable-line */}</div>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div>{/* eslint-disable-line-next */}</div>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div>{/* eslint-disable-line semi */}</div>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div>{/* eslint-disable-line-next semi */}</div>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+    ],
+    invalid: [
+        {
+            code: "/* eslint-disable-next-line */",
+            output: "// eslint-disable-next-line",
+            errors: ["Expected a line comment."],
+        },
+        {
+            code: "/* eslint-disable-next-line semi */",
+            output: "// eslint-disable-next-line semi",
+            errors: ["Expected a line comment."],
+        },
+        {
+            code: "/* eslint-disable-line semi */",
+            output: "// eslint-disable-line semi",
+            errors: ["Expected a line comment."],
+        },
+    ],
+})


### PR DESCRIPTION
This rule enforces `eslint-disable-line` and `eslint-disable-next-line` comments to be line comments instead of block comments.