### PR TITLE
#134 Allows require-description to be turned off for specific rules

### DIFF
--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -66,6 +66,14 @@ You can specify ignored directive-comments.
     - `"global"`
     - `"globals"`
 
+You can specify rules that don't require directive-comments.
+
+```json
+{
+    "@eslint-community/eslint-comments/require-description": ["error", {"disableForRules": []}]
+}
+```
+
 ## Further Reading
 
 - [ESLint RFCs - Description in directive comments]

--- a/lib/rules/require-description.js
+++ b/lib/rules/require-description.js
@@ -42,6 +42,14 @@ module.exports = {
                         additionalItems: false,
                         uniqueItems: true,
                     },
+					disableForRules: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
+						additionalItems: false,
+						uniqueItems: true,
+					},
                 },
                 additionalProperties: false,
             },
@@ -54,6 +62,9 @@ module.exports = {
         const ignores = new Set(
             (context.options[0] && context.options[0].ignore) || []
         )
+        const disableForRules = new Set(
+			(context.options[0] && context.options[0].disableForRules) || [],
+		);
 
         return {
             Program() {
@@ -66,6 +77,9 @@ module.exports = {
                     if (ignores.has(directiveComment.kind)) {
                         continue
                     }
+					if (disableForRules.has(directiveComment.ruleId)) {
+						continue;
+					}
                     if (!directiveComment.description) {
                         context.report({
                             loc: utils.toForceLocation(comment.loc),

--- a/tests/lib/rules/require-description.js
+++ b/tests/lib/rules/require-description.js
@@ -74,6 +74,10 @@ tester.run("require-description", rule, {
             code: "/* globals */",
             options: [{ ignore: ["globals"] }],
         },
+        {
+            code: "/* eslint-disable no-undef */",
+            options: [{ disableForRules: ["no-undef"] }],
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
Adds a new option to `require-description`, called `disableForRules`, which allows you to pass an array of rules that `require-description` will not apply to.

Example usage:

```js
"eslint-comments/require-description": [
	"error",
	{ ignore: [], disableForRules: ["no-unused-vars"] },
],
```

This can be especially helpful for overrides which are self-evident amongst users of the codebase.

Requested by #134.