### PR TITLE
feat: support ESLint v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
           - os: macos-latest
             eslint: 8
             node: 18
+          # On ESLint 9
+          - eslint: 9
+            node: 18
+            os: ubuntu-latest
           # On old ESLint versions
           - eslint: 7
             node: 18

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "escape-string-regexp": "^4.0.0",

--- a/tests/lib/illegal-eslint-disable-line.js
+++ b/tests/lib/illegal-eslint-disable-line.js
@@ -28,7 +28,11 @@ function runESLint(code) {
                 "--format",
                 "json",
             ],
-            { stdio: ["pipe", "pipe", "inherit"] }
+            {
+                stdio: ["pipe", "pipe", "inherit"],
+                // eslint-disable-next-line no-process-env, @eslint-community/mysticatea/node/no-process-env
+                env: { ...process.env, ESLINT_USE_FLAT_CONFIG: "false" },
+            }
         )
         const chunks = []
         let totalLength = 0

--- a/tests/lib/rules/no-restricted-disable.js
+++ b/tests/lib/rules/no-restricted-disable.js
@@ -7,11 +7,27 @@
 const semver = require("semver")
 const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-restricted-disable")
-const coreRules = new Linter().getRules()
-const tester = new RuleTester()
+const coreRules = new Linter({ configType: "eslintrc" }).getRules()
+let tester = null
 
-tester.defineRule("foo/no-undef", coreRules.get("no-undef"))
-tester.defineRule("foo/no-redeclare", coreRules.get("no-redeclare"))
+if (typeof RuleTester.prototype.defineRule === "function") {
+    // ESLint < 9
+    tester = new RuleTester()
+    tester.defineRule("foo/no-undef", coreRules.get("no-undef"))
+    tester.defineRule("foo/no-redeclare", coreRules.get("no-redeclare"))
+} else {
+    // ESLint 9
+    tester = new RuleTester({
+        plugins: {
+            foo: {
+                rules: {
+                    "no-undef": coreRules.get("no-undef"),
+                    "no-redeclare": coreRules.get("no-redeclare"),
+                },
+            },
+        },
+    })
+}
 
 tester.run("no-restricted-disable", rule, {
     valid: [

--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -47,7 +47,11 @@ function runESLint(code, reportUnusedDisableDirectives = false) {
                     ? ["--report-unused-disable-directives"]
                     : []),
             ],
-            { stdio: ["pipe", "pipe", "inherit"] }
+            {
+                stdio: ["pipe", "pipe", "inherit"],
+                // eslint-disable-next-line no-process-env, @eslint-community/mysticatea/node/no-process-env
+                env: { ...process.env, ESLINT_USE_FLAT_CONFIG: "false" },
+            }
         )
         const chunks = []
         let totalLength = 0


### PR DESCRIPTION
This PR adds support for ESLint v9 by extending the `peerDependencies` field in `package.json` and ensuring that the tests still pass on all supported versions of ESLint.