### PR TITLE
fixed typo in docs/index.md: missing "rules" property

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,9 @@ Either way, you can optionally configure individual rules:
     // ...
     comments.recommended,
     {
-        "@eslint-community/eslint-comments/no-unused-disable": "error"
+        rules: {
+            "@eslint-community/eslint-comments/no-unused-disable": "error"
+        }
     },
 ]
 ```


### PR DESCRIPTION
"rules" property is missing in the flat config example.