### PR TITLE
feat: add `name` to flat config (for tooling)

### DIFF
--- a/configs.js
+++ b/configs.js
@@ -11,6 +11,7 @@ const plugin = {
 
 module.exports = {
     recommended: {
+        name: '@eslint-community/eslint-comments/recommended',
         plugins: {
             "@eslint-community/eslint-comments": plugin,
         },


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

I did not add it to the older, non-flat configs because it will err there.