### PR TITLE
docs: fix configuration specs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,10 @@ Either way, you can optionally configure individual rules:
     // ...
     comments.recommended,
     {
-        "@eslint-community/eslint-comments/no-unused-disable": "error"
+        rules: {
+            "@eslint-community/eslint-comments/no-unused-disable": "error",
+            // ...
+        }
     },
 ]
 ```


### PR DESCRIPTION
Fix erroneous code example in flat configuration code within _Get Started_ section of documentaiton.