### PR TITLE
feat(no-unused-disable): deprecate rule

### DIFF
--- a/docs/rules/no-unused-disable.md
+++ b/docs/rules/no-unused-disable.md
@@ -7,6 +7,10 @@ In that case, you should remove the garbage as soon as possible since the garbag
 
 This rule warns unnecessary `eslint-disable` directive-comments.
 
+::: tip
+This rule is deprecated, since you can now use ESLint's built-in [`linterOptions.reportUnusedDisableDirectives`](https://eslint.org/docs/latest/use/configure/rules#report-unused-eslint-disable-comments) to report unused `eslint-disable` comments
+:::
+
 ## Rule Details
 
 Examples of :-1: **incorrect** code for this rule:

--- a/lib/rules/no-unused-disable.js
+++ b/lib/rules/no-unused-disable.js
@@ -9,6 +9,17 @@ require("../utils/patch")()
 
 module.exports = {
     meta: {
+        deprecated: {
+            availableUntil: "5.0.0",
+            deprecatedSince: "4.7.0",
+            message:
+                "ESLint now has built-in functionality to report unused `eslint-disable` comments",
+            replacedBy: {
+                message:
+                    "You can now use ESLint's built-in `linterOptions.reportUnusedDisabledDirectives` to report unused `eslint-disable` comments",
+                url: "https://eslint.org/docs/latest/use/configure/configuration-files#reporting-unused-disable-directives",
+            },
+        },
         docs: {
             description: "disallow unused `eslint-disable` comments",
             category: "Best Practices",


### PR DESCRIPTION
@eslint-community/eslint-plugin-eslint-comments Do we want to deprecate this rule in a minor release or do we include the deprecation in the next major release (which will also drop ESLint v6 & v7 support) and only remove it in the major release after that?