### PR TITLE
chore: add `.ncurc`

### DIFF
--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -1,0 +1,8 @@
+"use strict"
+
+module.exports = {
+    reject: [
+        // Reject updates until we switch to pure ESM
+        "escape-string-regexp",
+    ],
+}


### PR DESCRIPTION
An `.ncurc.cjs` file allows one to avoid auto-updates for particular packages when using `npm-check-updates`. In this case, it prevents auto-updating to a version of `escape-string-regexp` which is ESM-only.

Even if people wish to continue to use Dependabot, with all its attendant noise, it can still be helpful to those wishing to locally knock off a bunch of updates at once and let Dependabot adjust itself.