### PR TITLE
fix(docs): use `modern-monaco` instead of `monaco-editor`

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -23,11 +23,6 @@ export default defineConfig({
     vite: {
         publicDir: path.resolve(__dirname, "./public"),
         plugins: [eslint4b(), vitePluginGetLinter(), viteCommonjs()],
-        define: {
-            MONACO_EDITOR_VERSION: JSON.stringify(
-                require("monaco-editor/package.json").version
-            ),
-        },
     },
 
     lastUpdated: true,

--- a/docs/.vitepress/theme/components/eslint-editor.vue
+++ b/docs/.vitepress/theme/components/eslint-editor.vue
@@ -30,7 +30,7 @@ function createQuickfixCodeAction(title, marker, model, fix) {
     const start = model.getPositionAt(fix.range[0])
     const end = model.getPositionAt(fix.range[1])
     /**
-     * @type {import('monaco-editor').IRange}
+     * @type {import('modern-monaco/editor-core').IRange}
      */
     const editRange = {
         startLineNumber: start.lineNumber,

--- a/docs/.vitepress/theme/components/monaco/monaco-loader.mjs
+++ b/docs/.vitepress/theme/components/monaco/monaco-loader.mjs
@@ -1,69 +1,27 @@
-/* globals MONACO_EDITOR_VERSION */
-async function setupMonaco() {
-    if (typeof window !== "undefined") {
-        const monacoScript =
-            Array.from(document.head.querySelectorAll("script")).find(
-                (script) =>
-                    script.src &&
-                    script.src.includes("monaco") &&
-                    script.src.includes("vs/loader")
-            ) || (await appendMonacoEditorScript())
+import { init } from "modern-monaco"
 
-        // @ts-expect-error -- global Monaco's require
-        window.require.config({
-            paths: {
-                vs: monacoScript.src.replace(/\/vs\/.*$/u, "/vs"),
-            },
-        })
-    }
-}
+export const DARK_THEME_NAME = "github-dark"
 
-function appendMonacoEditorScript() {
-    return new Promise((resolve) => {
-        const script = document.createElement("script")
-        script.src = `https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/${MONACO_EDITOR_VERSION}/min/vs/loader.min.js`
-        script.onload = () => {
-            script.onload = null
+let monacoPromise = null
 
-            watch()
-
-            function watch() {
-                // @ts-expect-error -- global Monaco's require
-                if (window.require) {
-                    resolve(script)
-                    return
-                }
-                setTimeout(watch, 200)
-            }
-        }
-        document.head.append(script)
-    })
-}
-
-let setupedMonaco = null
-let editorLoaded = null
-
-export function loadMonacoEngine() {
-    return setupedMonaco || (setupedMonaco = setupMonaco())
-}
+/**
+ * Load Monaco Editor.
+ * @returns {Promise<import("modern-monaco/editor-core")>}
+ */
 export function loadMonacoEditor() {
-    if (editorLoaded) {
-        return editorLoaded
+    if (monacoPromise) {
+        return monacoPromise
     }
-    return (editorLoaded = (async () => {
-        const monaco = await loadModuleFromMonaco("vs/editor/editor.main")
-        return monaco
-    })())
-}
-
-export async function loadModuleFromMonaco(moduleName) {
-    await loadMonacoEngine()
-    return new Promise((resolve) => {
-        if (typeof window !== "undefined") {
-            // @ts-expect-error -- global Monaco's require
-            window.require([moduleName], (r) => {
-                resolve(r)
-            })
-        }
+    monacoPromise = init({
+        themes: [DARK_THEME_NAME],
+        lsp: {
+            typescript: {
+                diagnosticsOptions: {
+                    validate: false,
+                },
+            },
+        },
     })
+
+    return monacoPromise
 }

--- a/docs/.vitepress/theme/components/monaco/monaco-setup.mjs
+++ b/docs/.vitepress/theme/components/monaco/monaco-setup.mjs
@@ -1,4 +1,4 @@
-import { loadMonacoEditor } from "./monaco-loader.mjs"
+import { DARK_THEME_NAME, loadMonacoEditor } from "./monaco-loader.mjs"
 
 /** Setup editor */
 export async function setupMonacoEditor({
@@ -13,7 +13,7 @@ export async function setupMonacoEditor({
     const options = {
         value: init.value,
         readOnly: init.readOnly,
-        theme: "vs-dark",
+        theme: DARK_THEME_NAME,
         language,
         automaticLayout: true,
         fontSize: 14,

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "expect-type": "^1.3.0",
         "globals": "^13.24.0",
         "mocha": "^9.2.2",
-        "monaco-editor": "^0.55.1",
+        "modern-monaco": "^0.4.0",
         "npm-run-all2": "^8.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.2",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes the broken playground on the site by replacing the direct use of `monaco-editor` with `modern-monaco`.

https://github.com/esm-dev/modern-monaco

#### What changes did you make? (Give an overview)

Replace `monaco-editor` directly with `modern-monaco`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

I noticed that the playground on the site wasn't working, for example the code on the next page never finished loading.

https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html

#### Is there anything you'd like reviewers to focus on?

Previously, the monaco-editor documentation described using a CDN, but this has been deprecated and the documentation no longer appears to exist.
