### PR TITLE
fix(deps): pin `modern-monaco` version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "expect-type": "^1.3.0",
         "globals": "^13.24.0",
         "mocha": "^9.2.2",
-        "modern-monaco": "^0.4.0",
+        "modern-monaco": "0.4.0",
         "npm-run-all2": "^8.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-prettier": "^4.2.5",
         "expect-type": "^1.3.0",
+        "fflate": "0.8.2",
         "globals": "^13.24.0",
         "mocha": "^9.2.2",
         "modern-monaco": "0.4.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Using modern-monaco v0.4.1 causes installation failure due to a mismatch in the dependent TypeScript version. This also causes GitHub Actions CI to fail.

This PR fixes the problem by pinning modern-monaco to v0.4.0.

#### What changes did you make? (Give an overview)

This PR will pin modern-monaco to v0.4.0.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

https://github.com/eslint-community/eslint-plugin-eslint-comments/actions/runs/26234068527/job/77202402719

#### Is there anything you'd like reviewers to focus on?
