### PR TITLE
Handle missing require.cache when loading linters

### DIFF
--- a/lib/internal/get-linters.js
+++ b/lib/internal/get-linters.js
@@ -9,7 +9,7 @@ const needle = `${path.sep}node_modules${path.sep}eslint${path.sep}`
 
 module.exports = () => {
     const eslintPaths = new Set(
-        Object.keys(require.cache)
+        Object.keys(require.cache || {})
             .filter((id) => id.includes(needle))
             .map((id) => id.slice(0, id.indexOf(needle) + needle.length))
     )

--- a/tests/lib/internal/get-linters.js
+++ b/tests/lib/internal/get-linters.js
@@ -1,0 +1,64 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const assert = require("assert")
+const fs = require("fs")
+const path = require("path")
+const vm = require("vm")
+const Module = require("module")
+
+const getLintersPath = path.resolve(
+    __dirname,
+    "../../../lib/internal/get-linters.js"
+)
+
+/**
+ * Load `get-linters` in isolation with a `require` whose `cache` property is a
+ * given value. This mirrors ESM / bundled / patched-module contexts where
+ * `require.cache` can be `undefined` or `null`.
+ * @param {*} cacheValue The value to assign to `require.cache`.
+ * @returns {Function} The compiled `get-linters` export.
+ */
+function loadWithRequireCache(cacheValue) {
+    const source = fs.readFileSync(getLintersPath, "utf8")
+    const realRequire = Module.createRequire(getLintersPath)
+    const requireWithCache = (id) => realRequire(id)
+
+    requireWithCache.cache = cacheValue
+    requireWithCache.resolve = realRequire.resolve
+
+    const moduleObject = { exports: {} }
+    const compiled = vm.runInThisContext(Module.wrap(source), {
+        filename: getLintersPath,
+    })
+
+    compiled.call(
+        moduleObject.exports,
+        moduleObject.exports,
+        requireWithCache,
+        moduleObject,
+        getLintersPath,
+        path.dirname(getLintersPath)
+    )
+
+    return moduleObject.exports
+}
+
+describe("internal/get-linters", () => {
+    it("does not throw when require.cache is undefined", () => {
+        const getLinters = loadWithRequireCache(undefined)
+
+        assert.doesNotThrow(() => getLinters())
+        assert.ok(Array.isArray(getLinters()))
+    })
+
+    it("does not throw when require.cache is null", () => {
+        const getLinters = loadWithRequireCache(null)
+
+        assert.doesNotThrow(() => getLinters())
+        assert.ok(Array.isArray(getLinters()))
+    })
+})


### PR DESCRIPTION
Problem I saw:
Config loading could crash when `require.cache` was unavailable.
The failure was `TypeError: Cannot convert undefined or null to object`, from calling `Object.keys` directly on `require.cache`.

What I changed:
I added a small fallback so the cache scan uses an empty object when `require.cache` is missing.
The issue suggested nullish coalescing, but this repo still supports Node 12 and the lint rules reject that syntax, so I used `|| {}` instead.

How I checked it:
The new test failed before the fix for both `undefined` and `null` cache values with the reported error.
After the fix, the focused test passed with 2 tests. The full `tests/lib/**/*.js` run passed with 240 tests, and `npm run lint` plus `git diff --check` passed.

Closes #322